### PR TITLE
fix: add function to check the versions after semver

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,0 +1,42 @@
+import settings
+import requests
+import os
+
+# Function to download a file
+def download(url, file_name):
+    # open in binary mode
+    with open(file_name, "wb") as file:
+        # get request
+        response = requests.get(url)
+        # write to file
+        file.write(response.content)
+
+# Function to build the new version from source
+def buildFromSource(tag):
+    # Change to source dir
+    os.chdir(settings.source_dir)
+    # Checkout master
+    os.system("git checkout master")
+    # Update
+    os.system("git pull")
+    # Checkout relase branch
+    os.system("git checkout "+tag)
+    # Build from source
+    os.system('TAGS="bindata sqlite sqlite_unlock_notify" make generate build')
+    # Move binary
+    os.system("mv gitea "+settings.gtfile)
+
+# Function to create a list from a version string
+def getVersionList(string):
+    return list(map(int, string.split('.')))
+
+# Function to check if there is a new version
+def checkVersion(new_version, old_version):
+    new_version_list = getVersionList(new_version)
+    old_version_list = getVersionList(old_version)
+
+    for id, val in enumerate(new_version_list):
+        if val > old_version_list[id]:
+            return True
+
+    return None

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,19 @@
+import functions
+import unittest
+
+class Tests(unittest.TestCase):
+
+    def checkSimpleVersion(self):
+        self.assertTrue(functions.checkVersion('1.9.1', '1.9.0'))
+
+    def checkTwoIntVersion(self):
+        self.assertTrue(functions.checkVersion('1.10.0', '1.9.0'))
+
+    def checkFalseVersion(self):
+        self.assertFalse(functions.checkVersion('1.8.0', '1.9.0'))
+
+    def checkSameVersion(self):
+        self.assertFalse(functions.checkVersion('1.9.7', '1.9.7'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a function to check the two versions after the semver specification. Added some unit tests for testing the function too.

Does fix GH-1, was tested successfully.