### PR TITLE
Fixes: Make binary executable, fix isTool method signature, handle corrupted binary, and README tweaks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ apiUrl=https://api.github.com/repos/go-gitea/gitea/releases/latest
 system=linux-amd64
 file=/usr/local/bin/gitea
 tmpDir=/tmp/
-buildFromSource=None
-sourceDir=/home/git/go/src/code.gitea.io/gitea
+buildFromSource=
+sourceDir=
 logFile=update.log
   ````
 
 Use the following command to install gitea-auto-update.
 
   ```
-  sudo pip install gitea-auto-update
+  sudo pip3 install gitea-auto-update
   ```
 
 Enter the command `gite-auto-update --settings=/path/to/settings.ini` in your commandline.

--- a/gitea_auto_update/lib/download.py
+++ b/gitea_auto_update/lib/download.py
@@ -28,7 +28,7 @@ class Download:
         self.downloadGiteaFiles()
         self.checkAndExtract()
 
-    def isTool(name):
+    def isTool(self, name):
         # Function to check if tool is available
         ##Check whether `name` is on PATH and marked as executable.
         return which(name) is not None

--- a/gitea_auto_update/lib/download.py
+++ b/gitea_auto_update/lib/download.py
@@ -67,6 +67,8 @@ class Download:
         #  moving temp file to gtfile location
         cmd = 'mv ' + self.tmpDir + 'gitea-' + self.githubVersion + '-' + self.gtSystem + ' ' + self.gtFile
         os.system(cmd)
+        cmd = 'chmod +x ' + self.gtFile
+        os.system(cmd)
 
     def checkAndExtract(self):
         os.chdir(self.tmpDir)

--- a/gitea_auto_update/lib/version.py
+++ b/gitea_auto_update/lib/version.py
@@ -35,9 +35,13 @@ class Version:
             currentVersion = self.getVersionFromFile()
         except:
             # Get the version via the web api if the file does fail
-            currentVersion = requests.get(self.gtSite).json()['version']
-            if currentVersion.status_code != 200:
-                currentVersion = self.getVersionFromFile()
+            try:
+                currentVersion = requests.get(self.gtSite).json()['version']
+                if currentVersion.status_code != 200:
+                    raise RuntimeError("Could not download version.")
+            except:
+                # To allow installation, return a default version of "0.0.0".
+                currentVersion = "0.0.0"
         finally:
             logging.info('Version: current_version = %s', currentVersion)
             return currentVersion


### PR DESCRIPTION
This pull request includes the changes I needed to make the updater work on a Gitea server I'm running. It is running on Debian 10 and has been verified to work with the binary update mode.

- fix: Fix exception when updating via binary.
- fix: Make downloaded binary executable.
- feat: Handle nonexistent binary.
- feat: Update README with working configuration.

This pull request includes multiple changes. If you do not wish to incorporate a particular fix, please let me know and I can remove them from the request.